### PR TITLE
One missing img shouldn't crash an entire loop

### DIFF
--- a/objectfitcover.js
+++ b/objectfitcover.js
@@ -13,6 +13,11 @@
       for (var i = 0; i < elements.length; i++) {
         var img = elements[i].getElementsByTagName('img')[0];
 
+        if (!img) {
+          console.warn('Object fit container has no image:', elements[i]);
+          continue;
+        }
+
         // get current image src: Edge only supports 'currentSrc' for getting the current image src ('src' returns value DOM value)
         var imageSrc = img.currentSrc || img.src;
 


### PR DESCRIPTION
This is a small fix to account for cases where an image may or may not be placed inside an object fit container: this way it will just log a warning and at least continue to the other object fit containers to see if they _are_ valid.

(One small concern with this approach: because this is wrapped in a requestAnimationFrame, the warning will be displayed a number of times in a row which can sort of spam the console... any better ideas? Because it does feel right to warn the developer about this as it's not intended)